### PR TITLE
Add recipients for all test result emails

### DIFF
--- a/webapp/email-server.js
+++ b/webapp/email-server.js
@@ -3,8 +3,12 @@ const http = require("http");
 const nodemailer = require("nodemailer");
 require("dotenv").config();
 
-// Fixed recipient email
-const RECIPIENT_EMAIL = "xhuang@gmail.com";
+// Fixed recipient emails
+const RECIPIENT_EMAILS = [
+  "xhuang@gmail.com",
+  "iatchio@gmail.com",
+  "michellemsanjose@gmail.com",
+];
 
 // Define the website URL
 const WEBSITE_URL = process.env.WEBSITE_URL || "https://dmvtest-13aec.web.app";
@@ -243,12 +247,18 @@ const server = http.createServer(async (req, res) => {
         `;
 
         // Determine email recipients
-        let to = RECIPIENT_EMAIL; // Always include fixed email
-        
-        // Add user email if provided and valid, and different from fixed email
-        if (emailAddress && emailAddress.includes('@') && emailAddress !== RECIPIENT_EMAIL) {
-          to = `${RECIPIENT_EMAIL}, ${emailAddress}`;
+        const toEmails = [...RECIPIENT_EMAILS];
+
+        // Add user email if provided and valid, and not already included
+        if (
+          emailAddress &&
+          emailAddress.includes("@") &&
+          !RECIPIENT_EMAILS.includes(emailAddress)
+        ) {
+          toEmails.push(emailAddress);
         }
+
+        const to = toEmails.join(", ");
 
         // Create subject line with userName if available
         const subjectLine = (userName

--- a/website/public/email-test.html
+++ b/website/public/email-test.html
@@ -66,7 +66,7 @@
 </head>
 <body>
   <h1>DMV Test Email Sender</h1>
-  <p>Use this page to test sending DMV test results to xhuang@gmail.com</p>
+  <p>Use this page to test sending DMV test results to xhuang@gmail.com, iatchio@gmail.com, and michellemsanjose@gmail.com</p>
   
   <div class="form-group">
     <label for="userEmail">Your Email:</label>
@@ -97,7 +97,7 @@
   <button id="sendEmail">Send Test Results Email</button>
   
   <div id="successMessage" class="success">
-    Email sent successfully to xhuang@gmail.com!
+    Email sent successfully to xhuang@gmail.com, iatchio@gmail.com, and michellemsanjose@gmail.com!
   </div>
   
   <div id="errorMessage" class="error">


### PR DESCRIPTION
## Summary
- add `iatchio@gmail.com` and `michellemsanjose@gmail.com` to default recipients
- reflect new recipients on test email page

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test` *(fails: no test specified)*